### PR TITLE
remove `--global` option `git config`

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -8,8 +8,8 @@ printf "Setting username and password for Git ... (1/7)\n\n"
 GIT_USERNAME=gitName$Random
 GIT_EMAIL=a@b.c
 
-git config --global user.name "$GIT_USERNAME"
-git config --global user.email "$GIT_EMAIL"
+git config user.name "$GIT_USERNAME"
+git config user.email "$GIT_EMAIL"
 
 
 RESOURCE_GROUP=$(az group list --query "[0].name" -o tsv)


### PR DESCRIPTION
I removed `--global` option when executing `git config name ...` / `git config email ...`. If we execute this script on local machine, it causes configuration corruption. And, in the usecase of this script, I think local settings is enough for this configuration.